### PR TITLE
feat: redesenhar layout da pagina /plants (Issue #30)

### DIFF
--- a/src/app/[locale]/plants/page.tsx
+++ b/src/app/[locale]/plants/page.tsx
@@ -1,15 +1,14 @@
 import { FC } from "react";
-import { PlantCard } from "@/components/PlantCard";
 import { NoDataToShow } from "@/components/NoDataToShow";
 import DefaultLayout from "@/layouts/DefaultLayout";
 import { PlantsService } from "@/app/api/plants/plants.service";
-import { getUniqueId } from "@/utils/getUniqueId";
 import Loading from "@/components/Loading";
 import { Suspense } from "react";
 import { getTranslations } from 'next-intl/server';
 import { unstable_cache } from 'next/cache';
 import type { Metadata } from "next";
 import Script from "next/script";
+import { PlantCatalogClient } from "@/components/plants/PlantCatalogClient";
 
 export const metadata: Metadata = {
   title: "Plant Collection | Breath Natural - Premium Indoor Plants",
@@ -105,24 +104,14 @@ const PlantsPage: FC = async () => {
           }}
         />
         <DefaultLayout>
-          <div className="py-8 px-2 md:pt-[11rem]">
+          <div className="py-8 px-4 md:pt-[11rem] max-w-7xl mx-auto">
+            <h1 className="text-2xl md:text-3xl font-bold text-white mb-8">
+              {t('pageTitle')}
+            </h1>
             {plants.length === 0 ? (
               <NoDataToShow message={t('noPlantsMessage')} />
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-16 md:gap-6 md:gap-y-[12rem]">
-                {plants.map((plant, index) => (
-                  <PlantCard
-                    containerClassName="w-full bg-white/5 backdrop-blur-sm rounded-2xl p-6 relative flex flex-col items-center shadow-lg hover:shadow-xl transition-all duration-300 border border-white/10"
-                    imageClassName="rounded-full overflow-hidden !w-[120px] !h-[120px] md:!w-[9rem] md:!h-[9rem] !-mt-[2.5rem] md:!-mt-[10rem] shadow-lg border-4 border-white/10 ml-12"
-                    shopIconClassName="min-w-[17rem] w-full"
-                    quantityClassName="!min-w-[17rem] !w-full md:!ml-[11rem]"
-                    key={`${plant.id}-${index}-plant-card-${getUniqueId()}`}
-                    plant={plant}
-                    showExploreShortcut={false}
-                    showPrice
-                  />
-                ))}
-              </div>
+              <PlantCatalogClient plants={plants} />
             )}
           </div>
         </DefaultLayout>

--- a/src/blocks/buyShortcut.tsx
+++ b/src/blocks/buyShortcut.tsx
@@ -16,6 +16,7 @@ interface BuyShortcutProps {
   quantityClassName?: string;
   shopIconClassName?: string;
   loading?: boolean;
+  variant?: "default" | "compact";
 }
 
 export const BuyShortcut = ({
@@ -25,6 +26,7 @@ export const BuyShortcut = ({
   showIcon = true,
   quantityClassName,
   loading,
+  variant = "default",
 }: BuyShortcutProps) => {
   const { addItem } = useCartStore();
   const cartItems = useCartStore.getState().items;
@@ -34,6 +36,29 @@ export const BuyShortcut = ({
   const itemExistsOnCart = () => {
     return cartItems.some((item) => item.item.id === plant.id);
   };
+
+  if (variant === "compact") {
+    return itemExistsOnCart() ? (
+      <div className="flex items-center justify-center gap-3 py-2">
+        <QuantityShortcut
+          cartItem={{ item: plant, quantity: 1 }}
+          className={quantityClassName}
+        />
+      </div>
+    ) : (
+      <button
+        onClick={() => {
+          addItem(plant);
+          toast.success(`${plant.common_name || plant.scientific_name} ${t('success')}`);
+        }}
+        type="button"
+        className="w-full bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg py-2.5 font-medium text-sm transition-all duration-300 hover:shadow-lg hover:shadow-emerald-500/25"
+        title={`Buy ${plant.common_name || plant.scientific_name}`}
+      >
+        {t('addToCart')}
+      </button>
+    );
+  }
 
   return itemExistsOnCart() ? (
     <QuantityShortcut

--- a/src/blocks/sections/topSellingSection.tsx
+++ b/src/blocks/sections/topSellingSection.tsx
@@ -1,7 +1,6 @@
 import { QuotedTitle } from "@/components/QuotedTitle";
 import { useMockupPlants } from "@/hooks/mockupPlants";
 import { PlantCard } from "@/components/PlantCard";
-import { getUniqueId } from "@/utils/getUniqueId";
 import { useTranslations } from 'next-intl';
 
 export default function TopSellingSection() {
@@ -16,13 +15,11 @@ export default function TopSellingSection() {
         </QuotedTitle>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-center h-auto min-h-[90rem] w-full gap-[10rem] md:gap-y-[8rem] lg:gap-4 mt-[11rem] gap-y-[15rem]">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mt-8">
         {mockupPlants.slice(1, mockupPlants.length).map((plant, index) => (
           <PlantCard
-            containerClassName="w-full max-w-full min-w-full"
-            key={`${plant.id}-${index}-top-selling-${getUniqueId()}`}
+            key={`${plant.id}-${index}-top-selling`}
             plant={plant}
-            showPrice={true}
           />
         ))}
       </div>

--- a/src/components/PlantCard.tsx
+++ b/src/components/PlantCard.tsx
@@ -1,43 +1,77 @@
+"use client";
+
 import { Plant } from "@/types/plant.types";
-import { PlantCardContent } from "@/components/plantCardContent";
+import Image from "next/image";
+import { BuyShortcut } from "@/blocks/buyShortcut";
+import { BotanicalDetailsAccordion } from "@/components/plants/BotanicalDetailsAccordion";
+
+const DEFAULT_PRICE = "$59.99";
 
 interface PlantCardProps {
   plant: Plant;
-  containerClassName?: string;
-  imageClassName?: string;
-  titleClassName?: string;
-  showPrice?: boolean;
-  quantityClassName?: string;
-  showExploreShortcut?: boolean;
-  shopIconClassName?: string;
 }
 
-export function PlantCard({
-  plant,
-  containerClassName,
-  imageClassName,
-  titleClassName,
-  showPrice = false,
-  quantityClassName,
-  showExploreShortcut = true,
-  shopIconClassName,
-}: PlantCardProps) {
+export function PlantCard({ plant }: PlantCardProps) {
+  const displayName = plant.common_name || plant.scientific_name;
+
   return (
     <div
-      className={`relative bg-gradient-to-r from-white/10 via-transparent to-transparent backdrop-blur-md rounded-[32px] p-8 border border-white/20 w-full md:max-w-[25rem] max-h-[35rem] flex flex-col items-center animate-fade-in ${containerClassName}`}
+      className="group bg-white/5 backdrop-blur-sm rounded-2xl overflow-hidden border border-white/10 shadow-lg hover:shadow-2xl transition-all duration-300 animate-fade-in"
       role="article"
-      aria-label={`Plant card for ${plant.common_name || plant.scientific_name
-        }`}
+      aria-label={`Plant card for ${displayName}`}
     >
-      <PlantCardContent
-        plant={plant}
-        showPrice={showPrice}
-        imageClassName={imageClassName}
-        titleClassName={titleClassName}
-        quantityClassName={quantityClassName}
-        showExploreShortcut={showExploreShortcut}
-        shopIconClassName={shopIconClassName}
-      />
+      {/* Image section */}
+      <div className="relative aspect-[4/3] overflow-hidden">
+        {plant.image_url && (
+          <Image
+            src={plant.image_url}
+            alt={displayName}
+            fill
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            quality={85}
+            className="object-cover group-hover:scale-105 transition-transform duration-500"
+          />
+        )}
+
+        {/* Family badge */}
+        {plant.family && (
+          <span className="absolute top-3 right-3 bg-primary/80 backdrop-blur-sm text-white text-xs px-3 py-1 rounded-full border border-white/20">
+            {plant.family}
+          </span>
+        )}
+
+        {/* Price badge */}
+        <span className="absolute bottom-3 left-3 bg-accent text-primary font-bold text-sm px-3 py-1 rounded-lg">
+          {DEFAULT_PRICE}
+        </span>
+      </div>
+
+      {/* Content section */}
+      <div className="p-4">
+        <h3 className="text-white font-semibold text-lg leading-tight line-clamp-2">
+          {displayName}
+        </h3>
+        {plant.common_name && (
+          <p className="text-white/60 text-sm italic mt-1">
+            {plant.scientific_name}
+          </p>
+        )}
+
+        {/* Genus chip */}
+        {plant.genus && (
+          <span className="inline-block mt-2 text-xs bg-white/10 text-white/70 px-2 py-0.5 rounded-full">
+            {plant.genus}
+          </span>
+        )}
+
+        {/* CTA */}
+        <div className="mt-4">
+          <BuyShortcut plant={plant} variant="compact" />
+        </div>
+      </div>
+
+      {/* Botanical details accordion */}
+      <BotanicalDetailsAccordion plant={plant} />
     </div>
   );
 }

--- a/src/components/plants/BotanicalDetailsAccordion.tsx
+++ b/src/components/plants/BotanicalDetailsAccordion.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Plant } from "@/types/plant.types";
+import { useTranslations } from "next-intl";
+
+interface BotanicalDetailsAccordionProps {
+  plant: Plant;
+}
+
+export function BotanicalDetailsAccordion({ plant }: BotanicalDetailsAccordionProps) {
+  const t = useTranslations("plants");
+
+  return (
+    <details className="border-t border-white/10">
+      <summary className="px-4 py-3 text-sm text-white/60 cursor-pointer hover:text-white transition-colors flex items-center gap-2 select-none">
+        <span>ℹ️</span> {t("scientificInfo")}
+      </summary>
+      <div className="px-4 pb-4 text-xs text-white/50 space-y-1">
+        {plant.author && (
+          <p>
+            <span className="text-white/70">{t("author")}:</span> {plant.author}
+          </p>
+        )}
+        {plant.year > 0 && (
+          <p>
+            <span className="text-white/70">{t("year")}:</span> {plant.year}
+          </p>
+        )}
+        {plant.status && (
+          <p>
+            <span className="text-white/70">{t("status")}:</span> {plant.status}
+          </p>
+        )}
+        {plant.rank && (
+          <p>
+            <span className="text-white/70">{t("rank")}:</span> {plant.rank}
+          </p>
+        )}
+        {plant.bibliography && (
+          <p>
+            <span className="text-white/70">{t("bibliography")}:</span>{" "}
+            {plant.bibliography}
+          </p>
+        )}
+        {plant.family && (
+          <p>
+            <span className="text-white/70">{t("sortFamily")}:</span>{" "}
+            {plant.family}
+          </p>
+        )}
+        {plant.genus && (
+          <p>
+            <span className="text-white/70">Genus:</span> {plant.genus}
+          </p>
+        )}
+        {plant.synonyms.length > 0 && (
+          <p>
+            <span className="text-white/70">{t("synonyms")}:</span>{" "}
+            {plant.synonyms.join(", ")}
+          </p>
+        )}
+      </div>
+    </details>
+  );
+}

--- a/src/components/plants/PlantCatalogClient.tsx
+++ b/src/components/plants/PlantCatalogClient.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { Plant } from "@/types/plant.types";
+import { PlantCard } from "@/components/PlantCard";
+import { PlantSearchBar } from "@/components/plants/PlantSearchBar";
+import { PlantFamilyChips } from "@/components/plants/PlantFamilyChips";
+import { PlantSortDropdown, SortOption } from "@/components/plants/PlantSortDropdown";
+
+interface PlantCatalogClientProps {
+  plants: Plant[];
+}
+
+export function PlantCatalogClient({ plants }: PlantCatalogClientProps) {
+  const t = useTranslations("plants");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedFamily, setSelectedFamily] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortOption>("az");
+
+  const families = useMemo(
+    () => [...new Set(plants.map((p) => p.family))].filter(Boolean).sort(),
+    [plants]
+  );
+
+  const filteredPlants = useMemo(() => {
+    let result = [...plants];
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (p) =>
+          (p.common_name && p.common_name.toLowerCase().includes(query)) ||
+          p.scientific_name.toLowerCase().includes(query)
+      );
+    }
+
+    if (selectedFamily) {
+      result = result.filter((p) => p.family === selectedFamily);
+    }
+
+    switch (sortBy) {
+      case "az":
+        result.sort((a, b) =>
+          (a.common_name || a.scientific_name).localeCompare(
+            b.common_name || b.scientific_name
+          )
+        );
+        break;
+      case "za":
+        result.sort((a, b) =>
+          (b.common_name || b.scientific_name).localeCompare(
+            a.common_name || a.scientific_name
+          )
+        );
+        break;
+      case "family":
+        result.sort((a, b) => a.family.localeCompare(b.family));
+        break;
+    }
+
+    return result;
+  }, [plants, searchQuery, selectedFamily, sortBy]);
+
+  return (
+    <div>
+      {/* Search and filters */}
+      <div className="flex flex-col gap-4 mb-8">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <div className="flex-1">
+            <PlantSearchBar value={searchQuery} onChange={setSearchQuery} />
+          </div>
+          <PlantSortDropdown value={sortBy} onChange={setSortBy} />
+        </div>
+
+        {families.length > 1 && (
+          <PlantFamilyChips
+            families={families}
+            selected={selectedFamily}
+            onSelect={setSelectedFamily}
+          />
+        )}
+
+        <p className="text-white/50 text-sm">
+          {t("resultsCount", { count: filteredPlants.length })}
+        </p>
+      </div>
+
+      {/* Grid */}
+      {filteredPlants.length === 0 ? (
+        <p className="text-white/60 text-center py-12">{t("noResults")}</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
+          {filteredPlants.map((plant) => (
+            <PlantCard key={plant.id} plant={plant} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/plants/PlantFamilyChips.tsx
+++ b/src/components/plants/PlantFamilyChips.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface PlantFamilyChipsProps {
+  families: string[];
+  selected: string | null;
+  onSelect: (family: string | null) => void;
+}
+
+export function PlantFamilyChips({
+  families,
+  selected,
+  onSelect,
+}: PlantFamilyChipsProps) {
+  const t = useTranslations("plants");
+
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 scrollbar-none">
+      <button
+        onClick={() => onSelect(null)}
+        className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+          selected === null
+            ? "bg-accent text-primary"
+            : "bg-white/10 text-white border border-white/20 hover:bg-white/20"
+        }`}
+      >
+        {t("filterAll")}
+      </button>
+      {families.map((family) => (
+        <button
+          key={family}
+          onClick={() => onSelect(family)}
+          className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-all duration-200 ${
+            selected === family
+              ? "bg-accent text-primary"
+              : "bg-white/10 text-white border border-white/20 hover:bg-white/20"
+          }`}
+        >
+          {family}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/plants/PlantSearchBar.tsx
+++ b/src/components/plants/PlantSearchBar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface PlantSearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function PlantSearchBar({ value, onChange }: PlantSearchBarProps) {
+  const t = useTranslations("plants");
+
+  return (
+    <div className="relative">
+      <svg
+        className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-white/40"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+        />
+      </svg>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={t("searchPlaceholder")}
+        className="w-full bg-white/10 border border-white/20 rounded-xl pl-10 pr-4 py-3 text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-transparent transition-all"
+        aria-label={t("searchPlaceholder")}
+      />
+    </div>
+  );
+}

--- a/src/components/plants/PlantSortDropdown.tsx
+++ b/src/components/plants/PlantSortDropdown.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+export type SortOption = "az" | "za" | "family";
+
+interface PlantSortDropdownProps {
+  value: SortOption;
+  onChange: (value: SortOption) => void;
+}
+
+export function PlantSortDropdown({ value, onChange }: PlantSortDropdownProps) {
+  const t = useTranslations("plants");
+
+  return (
+    <div className="relative">
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value as SortOption)}
+        className="appearance-none bg-white/10 border border-white/20 rounded-xl px-4 py-3 pr-10 text-white text-sm focus:outline-none focus:ring-2 focus:ring-accent/50 focus:border-transparent cursor-pointer transition-all"
+        aria-label={t("sortBy")}
+      >
+        <option value="az" className="bg-primary text-white">
+          {t("sortAz")}
+        </option>
+        <option value="za" className="bg-primary text-white">
+          {t("sortZa")}
+        </option>
+        <option value="family" className="bg-primary text-white">
+          {t("sortFamily")}
+        </option>
+      </select>
+      <svg
+        className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-white/60 pointer-events-none"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    </div>
+  );
+}

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -8,7 +8,8 @@
     "message": "شراء نباتاتي"
   },
   "buyShortcut": {
-    "success": "تم إضافة المنتج إلى العربة"
+    "success": "تم إضافة المنتج إلى العربة",
+    "addToCart": "أضف إلى السلة"
   },
   "quantityShortcut": {
     "cancel": "إلغاء",
@@ -310,7 +311,23 @@
     "invalidDataError": "تم استلام بيانات غير صالحة من الخادم",
     "noPlantsMessage": "لا توجد نباتات للعرض...",
     "loadError": "خطأ في تحميل النباتات: {message}",
-    "genericError": "خطأ في تحميل النباتات..."
+    "genericError": "خطأ في تحميل النباتات...",
+    "pageTitle": "مجموعة النباتات",
+    "searchPlaceholder": "ابحث بالاسم...",
+    "sortAz": "أ-ي",
+    "sortZa": "ي-أ",
+    "sortFamily": "حسب العائلة",
+    "sortBy": "ترتيب حسب",
+    "filterAll": "الكل",
+    "noResults": "لم يتم العثور على نباتات",
+    "scientificInfo": "معلومات علمية",
+    "author": "المؤلف",
+    "year": "السنة",
+    "status": "الحالة",
+    "rank": "الرتبة",
+    "bibliography": "المراجع",
+    "synonyms": "المرادفات",
+    "resultsCount": "{count} نباتات"
   },
   "footer": {
     "home": "الرئيسية",

--- a/src/messages/br.json
+++ b/src/messages/br.json
@@ -8,7 +8,8 @@
     "message": "Compre-me um café"
   },
   "buyShortcut": {
-    "success": "adicionado ao carrinho"
+    "success": "adicionado ao carrinho",
+    "addToCart": "Adicionar"
   },
   "quantityShortcut": {
     "cancel": "Cancelar",
@@ -310,7 +311,23 @@
     "invalidDataError": "Dados inválidos recebidos do servidor",
     "noPlantsMessage": "Nenhuma planta para ser exibida...",
     "loadError": "Erro ao carregar as plantas: {message}",
-    "genericError": "Erro ao carregar as plantas..."
+    "genericError": "Erro ao carregar as plantas...",
+    "pageTitle": "Coleção de Plantas",
+    "searchPlaceholder": "Buscar por nome...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "Por Família",
+    "sortBy": "Ordenar por",
+    "filterAll": "Todos",
+    "noResults": "Nenhuma planta encontrada",
+    "scientificInfo": "Informações Científicas",
+    "author": "Autor",
+    "year": "Ano",
+    "status": "Status",
+    "rank": "Classificação",
+    "bibliography": "Bibliografia",
+    "synonyms": "Sinônimos",
+    "resultsCount": "{count} plantas encontradas"
   },
   "footer": {
     "home": "Home",

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -8,7 +8,8 @@
     "message": "Kaffee kaufen"
   },
   "buyShortcut": {
-    "success": "zum Warenkorb hinzugefügt"
+    "success": "zum Warenkorb hinzugefügt",
+    "addToCart": "In den Warenkorb"
   },
   "quantityShortcut": {
     "cancel": "Abbrechen",
@@ -310,7 +311,23 @@
     "invalidDataError": "Ungültige Daten vom Server erhalten",
     "noPlantsMessage": "Keine Pflanzen zum Anzeigen...",
     "loadError": "Fehler beim Laden der Pflanzen: {message}",
-    "genericError": "Fehler beim Laden der Pflanzen..."
+    "genericError": "Fehler beim Laden der Pflanzen...",
+    "pageTitle": "Pflanzensammlung",
+    "searchPlaceholder": "Nach Name suchen...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "Nach Familie",
+    "sortBy": "Sortieren nach",
+    "filterAll": "Alle",
+    "noResults": "Keine Pflanzen gefunden",
+    "scientificInfo": "Wissenschaftliche Informationen",
+    "author": "Autor",
+    "year": "Jahr",
+    "status": "Status",
+    "rank": "Rang",
+    "bibliography": "Bibliografie",
+    "synonyms": "Synonyme",
+    "resultsCount": "{count} Pflanzen gefunden"
   },
   "footer": {
     "home": "Startseite",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -8,7 +8,8 @@
     "message": "Buy me a coffee"
   },
   "buyShortcut": {
-    "success": "added to cart"
+    "success": "added to cart",
+    "addToCart": "Add to cart"
   },
   "quantityShortcut": {
     "cancel": "Cancel",
@@ -310,7 +311,23 @@
     "invalidDataError": "Invalid data received from server",
     "noPlantsMessage": "No plants to display...",
     "loadError": "Error loading plants: {message}",
-    "genericError": "Error loading plants..."
+    "genericError": "Error loading plants...",
+    "pageTitle": "Plant Collection",
+    "searchPlaceholder": "Search by name...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "By Family",
+    "sortBy": "Sort by",
+    "filterAll": "All",
+    "noResults": "No plants found matching your search",
+    "scientificInfo": "Scientific Information",
+    "author": "Author",
+    "year": "Year",
+    "status": "Status",
+    "rank": "Rank",
+    "bibliography": "Bibliography",
+    "synonyms": "Synonyms",
+    "resultsCount": "{count} plants found"
   },
   "menuItems": {
     "portfolio": "Portfolio",

--- a/src/messages/hi.json
+++ b/src/messages/hi.json
@@ -8,7 +8,8 @@
     "message": "मुझे एक कॉफी खरीदो"
   },
   "buyShortcut": {
-    "success": "शामिल करें गार्डन"
+    "success": "शामिल करें गार्डन",
+    "addToCart": "कार्ट में डालें"
   },
   "quantityShortcut": {
     "cancel": "बंद करें",
@@ -310,7 +311,23 @@
     "invalidDataError": "सर्वर से अमान्य डेटा प्राप्त हुआ",
     "noPlantsMessage": "प्रदर्शित करने के लिए कोई पौधे नहीं...",
     "loadError": "पौधे लोड करने में त्रुटि: {message}",
-    "genericError": "पौधे लोड करने में त्रुटि..."
+    "genericError": "पौधे लोड करने में त्रुटि...",
+    "pageTitle": "पौधों का संग्रह",
+    "searchPlaceholder": "नाम से खोजें...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "परिवार अनुसार",
+    "sortBy": "इसके अनुसार क्रमबद्ध करें",
+    "filterAll": "सभी",
+    "noResults": "कोई पौधे नहीं मिले",
+    "scientificInfo": "वैज्ञानिक जानकारी",
+    "author": "लेखक",
+    "year": "वर्ष",
+    "status": "स्थिति",
+    "rank": "श्रेणी",
+    "bibliography": "ग्रंथ सूची",
+    "synonyms": "समानार्थी",
+    "resultsCount": "{count} पौधे मिले"
   },
   "footer": {
     "home": "होम",

--- a/src/messages/jp.json
+++ b/src/messages/jp.json
@@ -8,7 +8,8 @@
     "message": "ブレス・ナチュラルをサポートしてください"
   },
   "buyShortcut": {
-    "success": "カートに追加されました"
+    "success": "カートに追加されました",
+    "addToCart": "カートに追加"
   },
   "quantityShortcut": {
     "cancel": "キャンセル",
@@ -310,7 +311,23 @@
     "invalidDataError": "サーバーから無効なデータを受信しました",
     "noPlantsMessage": "表示する植物がありません...",
     "loadError": "植物の読み込みエラー: {message}",
-    "genericError": "植物の読み込み中にエラーが発生しました..."
+    "genericError": "植物の読み込み中にエラーが発生しました...",
+    "pageTitle": "植物コレクション",
+    "searchPlaceholder": "名前で検索...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "科別",
+    "sortBy": "並び替え",
+    "filterAll": "すべて",
+    "noResults": "植物が見つかりません",
+    "scientificInfo": "学術情報",
+    "author": "著者",
+    "year": "年",
+    "status": "ステータス",
+    "rank": "ランク",
+    "bibliography": "参考文献",
+    "synonyms": "同義語",
+    "resultsCount": "{count}件の植物"
   },
   "footer": {
     "home": "ホーム",

--- a/src/messages/pl.json
+++ b/src/messages/pl.json
@@ -8,7 +8,8 @@
     "message": "Kup mi kawę"
   },
   "buyShortcut": {
-    "success": "dodane do koszyka"
+    "success": "dodane do koszyka",
+    "addToCart": "Dodaj do koszyka"
   },
   "quantityShortcut": {
     "cancel": "Anuluj",
@@ -310,7 +311,23 @@
     "invalidDataError": "Otrzymano nieprawidłowe dane z serwera",
     "noPlantsMessage": "Brak roślin do wyświetlenia...",
     "loadError": "Błąd podczas ładowania roślin: {message}",
-    "genericError": "Błąd podczas ładowania roślin..."
+    "genericError": "Błąd podczas ładowania roślin...",
+    "pageTitle": "Kolekcja roślin",
+    "searchPlaceholder": "Szukaj po nazwie...",
+    "sortAz": "A-Z",
+    "sortZa": "Z-A",
+    "sortFamily": "Wg rodziny",
+    "sortBy": "Sortuj według",
+    "filterAll": "Wszystkie",
+    "noResults": "Nie znaleziono roślin",
+    "scientificInfo": "Informacje naukowe",
+    "author": "Autor",
+    "year": "Rok",
+    "status": "Status",
+    "rank": "Ranga",
+    "bibliography": "Bibliografia",
+    "synonyms": "Synonimy",
+    "resultsCount": "Znaleziono {count} roślin"
   },
   "footer": {
     "home": "Strona główna",


### PR DESCRIPTION
## Summary

Redesign completo da página `/plants` com melhorias significativas de UX/UI:

- **Cards redesenhados**: imagem retangular aspect-ratio 4/3, nome comum como título principal, nome científico em itálico, badge de família sobreposto, preço visível, dados botânicos em accordion
- **Busca e filtros**: barra de busca por nome comum/científico, chips de filtro por família botânica, dropdown de ordenação (A-Z, Z-A, Família)
- **Grid responsivo**: 3 colunas desktop, 2 tablet, 1 mobile com gap consistente
- **CTA compacto**: botão "Adicionar" verde com feedback via toast (sonner)
- **Hover effects**: zoom sutil na imagem + elevação do card
- **7 idiomas**: traduções para en, br, ar, de, hi, jp, pl

## Componentes criados

| Arquivo | Descrição |
|---------|-----------|
| `PlantCatalogClient.tsx` | Client component com busca/filtro/ordenação |
| `PlantSearchBar.tsx` | Input de busca com ícone |
| `PlantFamilyChips.tsx` | Chips de filtro por família |
| `PlantSortDropdown.tsx` | Dropdown de ordenação |
| `BotanicalDetailsAccordion.tsx` | Accordion com dados científicos |

## Componentes modificados

- `PlantCard.tsx` — redesign completo
- `buyShortcut.tsx` — adicionado variant="compact"
- `topSellingSection.tsx` — adaptado para novo PlantCard
- `page.tsx` — integração com PlantCatalogClient
- 7 arquivos de tradução — novas chaves

## Test plan

- [x] `pnpm build` passa sem erros
- [ ] Cards exibem nome comum como título, científico em itálico
- [ ] Imagens retangulares com aspect-ratio consistente
- [ ] Busca funcional por nome comum e científico
- [ ] Chips de família filtram corretamente
- [ ] Dropdown de ordenação funciona
- [ ] Accordion abre/fecha dados botânicos
- [ ] Botão "Adicionar" funcional com toast
- [ ] Grid responsivo em mobile/tablet/desktop
- [ ] Hover com zoom na imagem + elevação

Closes #30

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)