### PR TITLE
Release: redesign /plants, revert home cards, fixes CI/seguranca

### DIFF
--- a/src/app/[locale]/plants/page.tsx
+++ b/src/app/[locale]/plants/page.tsx
@@ -104,7 +104,7 @@ const PlantsPage: FC = async () => {
           }}
         />
         <DefaultLayout>
-          <div className="py-8 px-4 md:pt-[11rem] max-w-7xl mx-auto">
+          <div className="py-8 px-4 max-w-7xl mx-auto">
             <h1 className="text-2xl md:text-3xl font-bold text-white mb-8">
               {t('pageTitle')}
             </h1>

--- a/src/blocks/sections/topSellingSection.tsx
+++ b/src/blocks/sections/topSellingSection.tsx
@@ -1,6 +1,7 @@
 import { QuotedTitle } from "@/components/QuotedTitle";
 import { useMockupPlants } from "@/hooks/mockupPlants";
-import { PlantCard } from "@/components/PlantCard";
+import { HomePlantCard } from "@/components/HomePlantCard";
+import { getUniqueId } from "@/utils/getUniqueId";
 import { useTranslations } from 'next-intl';
 
 export default function TopSellingSection() {
@@ -15,11 +16,13 @@ export default function TopSellingSection() {
         </QuotedTitle>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8 mt-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 justify-center h-auto min-h-[90rem] w-full gap-[10rem] md:gap-y-[8rem] lg:gap-4 mt-[11rem] gap-y-[15rem]">
         {mockupPlants.slice(1, mockupPlants.length).map((plant, index) => (
-          <PlantCard
-            key={`${plant.id}-${index}-top-selling`}
+          <HomePlantCard
+            containerClassName="w-full max-w-full min-w-full"
+            key={`${plant.id}-${index}-top-selling-${getUniqueId()}`}
             plant={plant}
+            showPrice={true}
           />
         ))}
       </div>

--- a/src/components/HomePlantCard.tsx
+++ b/src/components/HomePlantCard.tsx
@@ -1,0 +1,42 @@
+import { Plant } from "@/types/plant.types";
+import { PlantCardContent } from "@/components/plantCardContent";
+
+interface HomePlantCardProps {
+  plant: Plant;
+  containerClassName?: string;
+  imageClassName?: string;
+  titleClassName?: string;
+  showPrice?: boolean;
+  quantityClassName?: string;
+  showExploreShortcut?: boolean;
+  shopIconClassName?: string;
+}
+
+export function HomePlantCard({
+  plant,
+  containerClassName,
+  imageClassName,
+  titleClassName,
+  showPrice = false,
+  quantityClassName,
+  showExploreShortcut = true,
+  shopIconClassName,
+}: HomePlantCardProps) {
+  return (
+    <div
+      className={`relative bg-gradient-to-r from-white/10 via-transparent to-transparent backdrop-blur-md rounded-[32px] p-8 border border-white/20 w-full md:max-w-[25rem] max-h-[35rem] flex flex-col items-center animate-fade-in ${containerClassName}`}
+      role="article"
+      aria-label={`Plant card for ${plant.common_name || plant.scientific_name}`}
+    >
+      <PlantCardContent
+        plant={plant}
+        showPrice={showPrice}
+        imageClassName={imageClassName}
+        titleClassName={titleClassName}
+        quantityClassName={quantityClassName}
+        showExploreShortcut={showExploreShortcut}
+        shopIconClassName={shopIconClassName}
+      />
+    </div>
+  );
+}

--- a/src/components/PlantCard.tsx
+++ b/src/components/PlantCard.tsx
@@ -9,9 +9,10 @@ const DEFAULT_PRICE = "$59.99";
 
 interface PlantCardProps {
   plant: Plant;
+  showScientificDetails?: boolean;
 }
 
-export function PlantCard({ plant }: PlantCardProps) {
+export function PlantCard({ plant, showScientificDetails = false }: PlantCardProps) {
   const displayName = plant.common_name || plant.scientific_name;
 
   return (
@@ -71,7 +72,7 @@ export function PlantCard({ plant }: PlantCardProps) {
       </div>
 
       {/* Botanical details accordion */}
-      <BotanicalDetailsAccordion plant={plant} />
+      {showScientificDetails && <BotanicalDetailsAccordion plant={plant} />}
     </div>
   );
 }

--- a/src/components/plants/PlantCatalogClient.tsx
+++ b/src/components/plants/PlantCatalogClient.tsx
@@ -92,7 +92,7 @@ export function PlantCatalogClient({ plants }: PlantCatalogClientProps) {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 lg:gap-8">
           {filteredPlants.map((plant) => (
-            <PlantCard key={plant.id} plant={plant} />
+            <PlantCard key={plant.id} plant={plant} showScientificDetails />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Redesign completo da pagina /plants com busca, filtros, cards modernos e accordion botanico (PR #31)
- Restaurar layout original dos cards na home page via HomePlantCard (separado do PlantCard redesenhado)
- Accordion cientifico visivel apenas na pagina /plants
- Remover padding excessivo do topo da pagina plants
- Corrigir vulnerabilidade Next.js 15.1.3 → 15.1.12 (CVE-2025-66478)
- Migrar CI/CD de npm para pnpm
- Remover redirect catch-all no netlify.toml que causava erro 400 nas imagens

## Test plan

- [x] `pnpm build` passa sem erros
- [x] Layout da home preservado (cards glassmorphism + imagem circular)
- [x] Pagina /plants com cards redesenhados, busca, filtros e ordenacao
- [x] Accordion cientifico aparece apenas em /plants
- [x] CI GitHub Actions executa com pnpm

🤖 Generated with [OpenClaude](https://github.com/Gitlawb/openclaude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product prices now displayed in the top-selling section
  * Plant cards can optionally show scientific details

* **Style & Layout**
  * Updated spacing and layout in the top-selling section for improved visual hierarchy
  * Minor adjustments to main page container styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->